### PR TITLE
Add support for .ExtDescription in the Randoman's shop

### DIFF
--- a/gamemodes/terrortown/entities/entities/ttt_randoman_items/shared.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_randoman_items/shared.lua
@@ -178,8 +178,8 @@ if SERVER then
                     -- Update randomat description
                     local description = "'" .. longName .. "' is triggered when you buy this."
 
-                    if (event.Description and event.Description ~= "") or (event.AltDescription and event.AltDescription ~= "") then
-                        description = event.Description or event.AltDescription
+                    if (event.ExtDescription and #event.ExtDescription > 0) or (event.Description and #event.Description > 0) then
+                        description = event.ExtDescription or event.Description
 
                         if descriptionName then
                             description = longName .. "\n\n" .. description

--- a/gamemodes/terrortown/entities/entities/ttt_randoman_items/shared.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_randoman_items/shared.lua
@@ -178,8 +178,8 @@ if SERVER then
                     -- Update randomat description
                     local description = "'" .. longName .. "' is triggered when you buy this."
 
-                    if event.Description ~= nil and event.Description ~= "" then
-                        description = event.Description
+                    if (event.Description and event.Description ~= "") or (event.AltDescription and event.AltDescription ~= "") then
+                        description = event.Description or event.AltDescription
 
                         if descriptionName then
                             description = longName .. "\n\n" .. description


### PR DESCRIPTION
This is for randomats that need a description but shouldn't be shown when the randomat triggers. Is used in the Randomat ULX menu as well.