### PR TITLE
Misc. Randoman changes

### DIFF
--- a/gamemodes/terrortown/entities/entities/ttt_randoman_items/shared.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_randoman_items/shared.lua
@@ -1,13 +1,17 @@
 -- Don't run this if the randomat doesn't exist, the role obviously can't work then
 if not Randomat or type(Randomat.IsInnocentTeam) ~= "function" then return end
--- Remove the radar and body armour in the randoman's shop
-table.Empty(EquipmentItems[ROLE_RANDOMAN])
 local initialID = -1
 local finalID = -1
 local itemTotal = 15
 
 if not istable(DefaultEquipment[ROLE_RANDOMAN]) then
     DefaultEquipment[ROLE_RANDOMAN] = {}
+end
+
+for _, item in ipairs(EquipmentItems[ROLE_RANDOMAN]) do
+    if not table.HasValue(DefaultEquipment[ROLE_RANDOMAN], item.id) then
+        table.insert(DefaultEquipment[ROLE_RANDOMAN], item.id)
+    end
 end
 
 -- Creating dummy passive shop items for now, on server and client.
@@ -137,7 +141,7 @@ if SERVER then
 
                         -- Find a random event in that category that is allowed to run
                         for _, categoryEvent in ipairs(events) do
-                            if IsEventAllowed(categoryEvent) and Randomat:CanEventRun(categoryEvent, true) then
+                            if IsEventAllowed(categoryEvent) and Randomat:CanEventRun(categoryEvent) then
                                 event = categoryEvent
                                 break
                             end

--- a/gamemodes/terrortown/entities/entities/ttt_randoman_items/shared.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_randoman_items/shared.lua
@@ -8,6 +8,7 @@ if not istable(DefaultEquipment[ROLE_RANDOMAN]) then
     DefaultEquipment[ROLE_RANDOMAN] = {}
 end
 
+-- Make sure none of the default equipment has the "Custom" icon on it
 for _, item in ipairs(EquipmentItems[ROLE_RANDOMAN]) do
     if not table.HasValue(DefaultEquipment[ROLE_RANDOMAN], item.id) then
         table.insert(DefaultEquipment[ROLE_RANDOMAN], item.id)

--- a/lua/customroles/randoman.lua
+++ b/lua/customroles/randoman.lua
@@ -43,13 +43,17 @@ if SERVER then
         if GetConVar("ttt_randoman_prevent_auto_randomat"):GetBool() and player.IsRoleLiving(ROLE_RANDOMAN) then return false end
     end)
 
+    local blockedEvents = {
+        ["credits"] = "makes their role overpowered",
+        ["future"] = "can't consistently work with the dynamic shop events"
+    }
     -- Prevents a randomat from ever triggering if there is a Randoman in the round
     hook.Add("TTTRandomatCanEventRun", "HardBanRandomanEvents", function(event)
-        if event.Id ~= "credits" then return end
+        if not blockedEvents[event.Id] then return end
 
         for _, ply in ipairs(player.GetAll()) do
             if ply:IsRandoman() then
-                return false, "There is " .. ROLE_STRINGS_EXT[ROLE_RANDOMAN] .. " in the round and this event makes their role overpowered"
+                return false, "There is " .. ROLE_STRINGS_EXT[ROLE_RANDOMAN] .. " in the round and this event " .. blockedEvents[event.Id]
             end
         end
     end)

--- a/lua/customroles/randoman.lua
+++ b/lua/customroles/randoman.lua
@@ -44,6 +44,7 @@ if SERVER then
     end)
 
     local blockedEvents = {
+        ["blackmarket"] = "removes the main feature of the role",
         ["credits"] = "makes their role overpowered",
         ["future"] = "can't consistently work with the dynamic shop events"
     }

--- a/lua/customroles/santa.lua
+++ b/lua/customroles/santa.lua
@@ -245,12 +245,16 @@ if SERVER then
         end
     end)
 
+    local blockedEvents = {
+        ["blackmarket"] = "makes their cannon unusable",
+        ["future"] = "can't consistently work with the dynamic shop events"
+    }
     hook.Add("TTTRandomatCanEventRun", "Santa_TTTRandomatCanEventRun", function(event)
-        if event.Id ~= "blackmarket" then return end
+        if not blockedEvents[event.Id] then return end
 
         for _, ply in ipairs(player.GetAll()) do
             if ply:IsSanta() then
-                return false, "There is " .. ROLE_STRINGS_EXT[ROLE_SANTA] .. " in the round and this event makes their cannon unusable"
+                return false, "There is " .. ROLE_STRINGS_EXT[ROLE_SANTA] .. " in the round and this event " .. blockedEvents[event.Id]
             end
         end
     end)


### PR DESCRIPTION
**Randoman**
- Added Future Proofing and Black Market Buyout to the blocked events while there is a Randoman
- Added the ability to always have specific events in the Randoman shop, starting with "What Did I Find in My Pocket?"
- Changed Randoman to have the radar and parasite cure in the shop, like all the other special detectives
- Fixed events that are blocked by event history still being chosen for the Randoman shop even though they can't be started

**Santa**
- Added Future Proofing to the blocked events while there is a Santa