### PR TITLE
Randoman beggar changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ ttt_randoman_prevent_auto_randomat   1    // Prevent auto-randomat triggering if
 ttt_randoman_guaranteed_categories   biased_innocent,fun,moderateimpact    // A randomat from these categories is guaranteed be in the randoman's shop, separate categories with commas.
 // Categories: biased_innocent, biased_traitor, biased_zombie, biased, deathtrigger, entityspawn, eventtrigger, fun, gamemode, item, largeimpact, moderateimpact, rolechange, smallimpact, spectator, stats
 ttt_randoman_guaranteed_randomats    ""   // These events are guaranteed be in the randoman's shop, separate event IDs with commas.
+ttt_randoman_event_on_unbought_death 1    // Whether a randomat should trigger if a randoman dies and never bought anything that round
 ```
 
 ## Santa

--- a/README.md
+++ b/README.md
@@ -52,8 +52,7 @@ ttt_randoman_prevent_auto_randomat   1    // Prevent auto-randomat triggering if
 ttt_randoman_guaranteed_categories   biased_innocent,fun,moderateimpact    // A randomat from these categories is guaranteed be in the randoman's shop, separate categories with commas.
 // Categories: biased_innocent, biased_traitor, biased_zombie, biased, deathtrigger, entityspawn, eventtrigger, fun, gamemode, item, largeimpact, moderateimpact, rolechange, smallimpact, spectator, stats
 ttt_randoman_guaranteed_randomats    ""   // These events are guaranteed be in the randoman's shop, separate event IDs with commas.
-ttt_randoman_event_on_unbought_death 1    // Whether a randomat should trigger if a randoman dies and never bought anything that round
-ttt_randoman_give_used_randomats     1    // Whether a randoman should receive a "used randomat" item on buying an event, for converting the beggar, if the beggar is enabled
+ttt_randoman_event_on_unbought_death 0    // Whether a randomat should trigger if a randoman dies and never bought anything that round
 ```
 
 ## Santa

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ ttt_randoman_guaranteed_categories   biased_innocent,fun,moderateimpact    // A 
 // Categories: biased_innocent, biased_traitor, biased_zombie, biased, deathtrigger, entityspawn, eventtrigger, fun, gamemode, item, largeimpact, moderateimpact, rolechange, smallimpact, spectator, stats
 ttt_randoman_guaranteed_randomats    ""   // These events are guaranteed be in the randoman's shop, separate event IDs with commas.
 ttt_randoman_event_on_unbought_death 1    // Whether a randomat should trigger if a randoman dies and never bought anything that round
+ttt_randoman_give_used_randomats     1    // Whether a randoman should receive a "used randomat" item on buying an event, for converting the beggar, if the beggar is enabled
 ```
 
 ## Santa

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ ttt_randoman_guaranteed_categories   biased_innocent,fun,moderateimpact    // A 
 // Categories: biased_innocent, biased_traitor, biased_zombie, biased, deathtrigger, entityspawn, eventtrigger, fun, gamemode, item, largeimpact, moderateimpact, rolechange, smallimpact, spectator, stats
 ttt_randoman_guaranteed_randomats    ""   // These events are guaranteed be in the randoman's shop, separate event IDs with commas.
 ttt_randoman_event_on_unbought_death 0    // Whether a randomat should trigger if a randoman dies and never bought anything that round
+ttt_randoman_choose_event_on_drop    1    // Whether the held randomat item should always trigger "Choose an event!" after being bought by a randoman and dropped on the ground
+ttt_randoman_guarantee_pockets_event 1    // Whether the "What did I find in my pocket?" event should always be available in the randoman's shop while the beggar role is enabled
 ```
 
 ## Santa

--- a/gamemodes/terrortown/entities/entities/ttt_randoman_items/shared.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_randoman_items/shared.lua
@@ -73,24 +73,6 @@ if SERVER then
 
     local triggeredEvents = {}
 
-    local function GiveUsedRandomat(ply)
-        if not GetConVar("ttt_beggar_enabled"):GetBool() or not GetConVar("ttt_randoman_give_used_randomats"):GetBool() then return end
-        local SWEP = ply:Give("weapon_ttt_randomat")
-        if not IsValid(SWEP) then return end
-        SWEP.AllowDrop = true
-
-        -- Don't trigger a randomat on use, instead display a message
-        function SWEP:PrimaryAttack()
-            if SERVER and IsFirstTimePredicted() then
-                local owner = self:GetOwner()
-
-                if IsValid(owner) and owner:IsPlayer() then
-                    owner:PrintMessage(HUD_PRINTCENTER, "This randomat is used up! But someone might still want it...")
-                end
-            end
-        end
-    end
-
     -- Trigger a randomat event when a randoman item is bought
     hook.Add("TTTOrderedEquipment", "RandomanItemBought", function(ply, id, is_item)
         if is_item and IsRandomanItem(id) then
@@ -103,8 +85,6 @@ if SERVER then
 
             Randomat:TriggerEvent(item.eventid, ply)
             table.insert(triggeredEvents, item.eventid)
-            -- Give the randoman a "used randomat" item if the beggar (and the convar) is enabled, used for converting the beggar
-            GiveUsedRandomat(ply)
         end
     end)
 
@@ -136,6 +116,11 @@ if SERVER then
             forcedEvents = string.Explode(",", forcedEventsString)
         else
             forcedEvents = {}
+        end
+
+        -- Add the 'What did I find in my pocket?' event to the randoman's shop if the beggar is enabled
+        if not table.HasValue(forcedEvents, "pocket") and GetConVar("ttt_beggar_enabled"):GetBool() then
+            table.insert(forcedEvents, "pocket")
         end
     end)
 

--- a/gamemodes/terrortown/entities/entities/ttt_randoman_items/shared.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_randoman_items/shared.lua
@@ -73,6 +73,24 @@ if SERVER then
 
     local triggeredEvents = {}
 
+    local function GiveUsedRandomat(ply)
+        if not GetConVar("ttt_beggar_enabled"):GetBool() or not GetConVar("ttt_randoman_give_used_randomats"):GetBool() then return end
+        local SWEP = ply:Give("weapon_ttt_randomat")
+        if not IsValid(SWEP) then return end
+        SWEP.AllowDrop = true
+
+        -- Don't trigger a randomat on use, instead display a message
+        function SWEP:PrimaryAttack()
+            if SERVER and IsFirstTimePredicted() then
+                local owner = self:GetOwner()
+
+                if IsValid(owner) and owner:IsPlayer() then
+                    owner:PrintMessage(HUD_PRINTCENTER, "This could be used as a gift for someone...")
+                end
+            end
+        end
+    end
+
     -- Trigger a randomat event when a randoman item is bought
     hook.Add("TTTOrderedEquipment", "RandomanItemBought", function(ply, id, is_item)
         if is_item and IsRandomanItem(id) then
@@ -85,6 +103,8 @@ if SERVER then
 
             Randomat:TriggerEvent(item.eventid, ply)
             table.insert(triggeredEvents, item.eventid)
+            -- Give the randoman a "used randomat" item if the beggar (and the convar) is enabled, used for converting the beggar
+            GiveUsedRandomat(ply)
         end
     end)
 
@@ -149,7 +169,6 @@ if SERVER then
 
     local function RandomizeEvents()
         if eventsRandomized then return end
-
         table.Empty(chosenEvents)
         local guaranteedItemCount = 0
         local guaranteedItemTotal = #guaranteedEventCategories

--- a/gamemodes/terrortown/entities/entities/ttt_randoman_items/shared.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_randoman_items/shared.lua
@@ -118,8 +118,8 @@ if SERVER then
             forcedEvents = {}
         end
 
-        -- Add the 'What did I find in my pocket?' event to the randoman's shop if the beggar is enabled
-        if not table.HasValue(forcedEvents, "pocket") and GetConVar("ttt_beggar_enabled"):GetBool() then
+        -- Add the 'What did I find in my pocket?' event to the randoman's shop if the beggar and convar is enabled
+        if not table.HasValue(forcedEvents, "pocket") and GetConVar("ttt_beggar_enabled"):GetBool() and GetConVar("ttt_randoman_guarantee_pockets_event"):GetBool() then
             table.insert(forcedEvents, "pocket")
         end
     end)

--- a/gamemodes/terrortown/entities/entities/ttt_randoman_items/shared.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_randoman_items/shared.lua
@@ -93,7 +93,7 @@ if SERVER then
     local guaranteedEventCategories = {}
     local forcedEvents = {}
 
-    -- Update the banned randomats list, and guarantee 'What did I find in my pocket?' if the beggar is enabled.
+    -- Update the banned randomats list
     -- This hook is called repeatedly, to allow for changing the convars round-to-round
     hook.Add("TTTUpdateRoleState", "UpdateBannedRandomanEvents", function()
         local bannedEventsString = GetConVar("ttt_randoman_banned_randomats"):GetString()
@@ -116,11 +116,6 @@ if SERVER then
             forcedEvents = string.Explode(",", forcedEventsString)
         else
             forcedEvents = {}
-        end
-
-        -- Add the 'What did I find in my pocket?' event to the randoman's shop if the beggar is enabled, and they don't already have access to the parasite cure
-        if not table.HasValue(forcedEvents, "pocket") and GetConVar("ttt_beggar_enabled"):GetBool() and not GetConVar("ttt_parasite_enabled"):GetBool() then
-            table.insert(forcedEvents, "pocket")
         end
     end)
 

--- a/gamemodes/terrortown/entities/entities/ttt_randoman_items/shared.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_randoman_items/shared.lua
@@ -85,7 +85,7 @@ if SERVER then
                 local owner = self:GetOwner()
 
                 if IsValid(owner) and owner:IsPlayer() then
-                    owner:PrintMessage(HUD_PRINTCENTER, "This could be used as a gift for someone...")
+                    owner:PrintMessage(HUD_PRINTCENTER, "This randomat is used up! But someone might still want it...")
                 end
             end
         end

--- a/lua/customroles/randoman.lua
+++ b/lua/customroles/randoman.lua
@@ -110,7 +110,7 @@ if SERVER then
 
     -- Triggering a random event if the randoman dies and hasn't bought anything, and the convar is enabled
     hook.Add("PostPlayerDeath", "RandomanDeathEventTrigger", function(ply)
-        if ply:IsRandoman() and eventOnUnboughtDeathCvar:GetBool() and not boughtAsRandoman[ply] then
+        if ply:IsRandoman() and GetRoundState() == ROUND_ACTIVE and eventOnUnboughtDeathCvar:GetBool() and not boughtAsRandoman[ply] then
             Randomat:TriggerRandomEvent(ply)
             -- Just in case the randoman somehow respawns, only trigger a randomat on death once
             boughtAsRandoman[ply] = true

--- a/lua/customroles/randoman.lua
+++ b/lua/customroles/randoman.lua
@@ -103,7 +103,7 @@ if SERVER then
 
     -- Triggering a random event if the randoman dies and hasn't bought anything, and the convar is enabled
     hook.Add("PostPlayerDeath", "RandomanDeathEventTrigger", function(ply)
-        if eventOnUnboughtDeathCvar:GetBool() and not boughtAsRandoman[ply] then
+        if ply:IsRandoman() and eventOnUnboughtDeathCvar:GetBool() and not boughtAsRandoman[ply] then
             Randomat:TriggerRandomEvent(ply)
             -- Just in case the randoman somehow respawns, only trigger a randomat on death once
             boughtAsRandoman[ply] = true

--- a/lua/customroles/randoman.lua
+++ b/lua/customroles/randoman.lua
@@ -25,6 +25,8 @@ CreateConVar("ttt_randoman_guaranteed_randomats", "", {FCVAR_NOTIFY}, "Events th
 
 local eventOnUnboughtDeathCvar = CreateConVar("ttt_randoman_event_on_unbought_death", 1, {FCVAR_NOTIFY}, "Whether a randomat should trigger if a randoman dies and never bought anything that round", 0, 1)
 
+CreateConVar("ttt_randoman_give_used_randomats", 1, {FCVAR_NOTIFY}, "Whether a randoman should receive a 'used randomat' item on buying an event for converting the beggar, if the beggar is enabled")
+
 ROLE.convars = {
     {
         cvar = "ttt_randoman_banned_randomats",
@@ -45,7 +47,11 @@ ROLE.convars = {
     {
         cvar = "ttt_randoman_event_on_unbought_death",
         type = ROLE_CONVAR_TYPE_BOOL
-    }
+    },
+    {
+        cvar = "ttt_randoman_give_used_randomats",
+        type = ROLE_CONVAR_TYPE_BOOL
+    },
 }
 
 RegisterRole(ROLE)

--- a/lua/customroles/randoman.lua
+++ b/lua/customroles/randoman.lua
@@ -87,6 +87,13 @@ if SERVER then
 
                 if IsValid(SWEP) then
                     SWEP.AllowDrop = true
+
+                    -- If the randoman drops this item, it is guaranteed to trigger "Choose an event!" on being picked up and used, which gives the player a choice of 5 randomats to trigger. This is so the randoman is able to give other players an interesting item, most notably for players that are the beggar role
+                    function SWEP:OnDrop()
+                        self.EventId = "choose"
+
+                        self.EventArgs = {false, false, nil, 5}
+                    end
                 end
             end
 

--- a/lua/customroles/randoman.lua
+++ b/lua/customroles/randoman.lua
@@ -7,7 +7,7 @@ ROLE.nameshort = "ran"
 ROLE.desc = [[You are {role}!
 You're {adetective}, but you can buy randomats instead of {detective} items!]]
 ROLE.team = ROLE_TEAM_DETECTIVE
-ROLE.shop = {}
+ROLE.shop = {"weapon_ttt_randomat"}
 ROLE.loadout = {}
 ROLE.startingcredits = 1
 ROLE.selectionpredicate = function() return Randomat and type(Randomat.IsInnocentTeam) == "function" end

--- a/lua/customroles/randoman.lua
+++ b/lua/customroles/randoman.lua
@@ -104,8 +104,16 @@ if SERVER then
         end
     end)
 
-    hook.Add("TTTPrepareRound", "RandomanBoughtItemReset", function()
+    local autoRandomatExists = false
+
+    hook.Add("TTTPrepareRound", "RandomanReset", function()
         table.Empty(boughtAsRandoman)
+        SetGlobalBool("ttt_randoman_prevent_auto_randomat", GetConVar("ttt_randoman_prevent_auto_randomat"):GetBool())
+
+        if autoRandomatExists or ConVarExists("ttt_randomat_auto") then
+            autoRandomatExists = true
+            SetGlobalBool("ttt_randomat_auto", GetConVar("ttt_randomat_auto"):GetBool())
+        end
     end)
 
     -- Triggering a random event if the randoman dies and hasn't bought anything, and the convar is enabled
@@ -125,7 +133,7 @@ if CLIENT then
             local teamColor = GetRoleTeamColor(ROLE_TEAM_INNOCENT)
             local html = "The " .. ROLE_STRINGS[ROLE_RANDOMAN] .. " is a " .. ROLE_STRINGS[ROLE_DETECTIVE] .. " and a member of the <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>innocent team</span> who is able to buy randomat events, rather than <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>" .. ROLE_STRINGS[ROLE_DETECTIVE] .. "</span> items. <br><br>The available randomat events <span style='color: rgb(" .. teamColor.r .. ", " .. teamColor.g .. ", " .. teamColor.b .. ")'>change each round</span>, and are shared between everyone who is a " .. ROLE_STRINGS[ROLE_RANDOMAN] .. ".<br><br>Some randomat events <span style='color: rgb(" .. teamColor.r .. ", " .. teamColor.g .. ", " .. teamColor.b .. ")'>cannot be bought</span>, such as ones that are supposed to start secretly."
 
-            if preventAutoRandomatCvar:GetBool() and ConVarExists("ttt_randomat_auto") and GetConVar("ttt_randomat_auto"):GetBool() then
+            if GetGlobalBool("ttt_randoman_prevent_auto_randomat") and GetGlobalBool("ttt_randomat_auto") then
                 html = html .. "<br><br>If a " .. ROLE_STRINGS[ROLE_RANDOMAN] .. " spawns at the start of the round, <span style='color: rgb(" .. teamColor.r .. ", " .. teamColor.g .. ", " .. teamColor.b .. ")'>no randomat automatically triggers</span>."
             end
 

--- a/lua/customroles/randoman.lua
+++ b/lua/customroles/randoman.lua
@@ -25,8 +25,6 @@ CreateConVar("ttt_randoman_guaranteed_randomats", "", {FCVAR_NOTIFY}, "Events th
 
 local eventOnUnboughtDeathCvar = CreateConVar("ttt_randoman_event_on_unbought_death", 1, {FCVAR_NOTIFY}, "Whether a randomat should trigger if a randoman dies and never bought anything that round", 0, 1)
 
-CreateConVar("ttt_randoman_give_used_randomats", 1, {FCVAR_NOTIFY}, "Whether a randoman should receive a 'used randomat' item on buying an event for converting the beggar, if the beggar is enabled")
-
 ROLE.convars = {
     {
         cvar = "ttt_randoman_banned_randomats",
@@ -47,11 +45,7 @@ ROLE.convars = {
     {
         cvar = "ttt_randoman_event_on_unbought_death",
         type = ROLE_CONVAR_TYPE_BOOL
-    },
-    {
-        cvar = "ttt_randoman_give_used_randomats",
-        type = ROLE_CONVAR_TYPE_BOOL
-    },
+    }
 }
 
 RegisterRole(ROLE)

--- a/lua/customroles/randoman.lua
+++ b/lua/customroles/randoman.lua
@@ -76,12 +76,22 @@ if SERVER then
         end
     end)
 
-    -- Detecting if the randoman has bought anything
     local boughtAsRandoman = {}
-
+    
     hook.Add("TTTOrderedEquipment", "RandomanBoughtItem", function(ply, id, is_item, from_randomat)
-        if ply:IsRandoman() and not from_randomat then
-            boughtAsRandoman[ply] = true
+        if ply:IsRandoman() then
+            -- Let the randoman be able to drop the randomat SWEP
+            if id == "weapon_ttt_randomat" then
+                local SWEP = ply:GetWeapon("weapon_ttt_randomat")
+                if IsValid(SWEP) then
+                    SWEP.AllowDrop = true
+                end
+            end
+            
+            -- Detecting if the randoman has bought anything
+            if not from_randomat then
+                boughtAsRandoman[ply] = true
+            end
         end
     end)
 

--- a/lua/customroles/randoman.lua
+++ b/lua/customroles/randoman.lua
@@ -15,11 +15,13 @@ ROLE.selectionpredicate = function() return Randomat and type(Randomat.IsInnocen
 -- Lame is pointless to have in the shop as it itself does nothing
 CreateConVar("ttt_randoman_banned_randomats", "lame", {FCVAR_NOTIFY}, "Events not allowed in the randoman's shop, separate ids with commas. You can find an ID by turning a randomat on/off in the randomat ULX menu and copying the word after 'ttt_randomat_', which appears in chat.")
 
-CreateConVar("ttt_randoman_prevent_auto_randomat", 1, {FCVAR_NOTIFY}, "Prevent auto-randomat triggering if there is a randoman at the start of the round", 0, 1)
+local preventAutoRandomatCvar = CreateConVar("ttt_randoman_prevent_auto_randomat", 1, {FCVAR_NOTIFY}, "Prevent auto-randomat triggering if there is a randoman at the start of the round", 0, 1)
 
 CreateConVar("ttt_randoman_guaranteed_categories", "biased_innocent,fun,moderateimpact", {FCVAR_NOTIFY}, "At least one randomat from each of these categories will always be in the randoman's shop. You can find a randomat's category by looking at an event in the randomat ULX menu.")
 
 CreateConVar("ttt_randoman_guaranteed_randomats", "", {FCVAR_NOTIFY}, "Events that will always appear in the randoma's shop, separate ids with commas.")
+
+local eventOnUnboughtDeathCvar = CreateConVar("ttt_randoman_event_on_unbought_death", 1, {FCVAR_NOTIFY}, "Whether a randomat should trigger if a randoman dies and never bought anything that round", 0, 1)
 
 ROLE.convars = {
     {
@@ -37,6 +39,10 @@ ROLE.convars = {
     {
         cvar = "ttt_randoman_guaranteed_randomats",
         type = ROLE_CONVAR_TYPE_TEXT
+    },
+    {
+        cvar = "ttt_randoman_event_on_unbought_death",
+        type = ROLE_CONVAR_TYPE_BOOL
     }
 }
 
@@ -50,7 +56,7 @@ if SERVER then
 
     -- Prevents auto-randomat triggering if there is a Randoman alive
     hook.Add("TTTRandomatShouldAuto", "StopAutoRandomatWithRandoman", function()
-        if GetConVar("ttt_randoman_prevent_auto_randomat"):GetBool() and player.IsRoleLiving(ROLE_RANDOMAN) then return false end
+        if preventAutoRandomatCvar:GetBool() and player.IsRoleLiving(ROLE_RANDOMAN) then return false end
     end)
 
     local blockedEvents = {
@@ -69,6 +75,28 @@ if SERVER then
             end
         end
     end)
+
+    -- Detecting if the randoman has bought anything
+    local boughtAsRandoman = {}
+
+    hook.Add("TTTOrderedEquipment", "RandomanBoughtItem", function(ply, id, is_item, from_randomat)
+        if ply:IsRandoman() and not from_randomat then
+            boughtAsRandoman[ply] = true
+        end
+    end)
+
+    hook.Add("TTTPrepareRound", "RandomanBoughtItemReset", function()
+        table.Empty(boughtAsRandoman)
+    end)
+
+    -- Triggering a random event if the randoman dies and hasn't bought anything, and the convar is enabled
+    hook.Add("PostPlayerDeath", "RandomanDeathEventTrigger", function (ply)
+        if eventOnUnboughtDeathCvar:GetBool() and not boughtAsRandoman[ply] then
+            Randomat:TriggerRandomEvent(ply)
+            -- Just in case the randoman somehow respawns, only trigger a randomat on death once
+            boughtAsRandoman[ply] = true
+        end
+    end)
 end
 
 if CLIENT then
@@ -78,7 +106,7 @@ if CLIENT then
             local teamColor = GetRoleTeamColor(ROLE_TEAM_INNOCENT)
             local html = "The " .. ROLE_STRINGS[ROLE_RANDOMAN] .. " is a " .. ROLE_STRINGS[ROLE_DETECTIVE] .. " and a member of the <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>innocent team</span> who is able to buy randomat events, rather than <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>" .. ROLE_STRINGS[ROLE_DETECTIVE] .. "</span> items. <br><br>The available randomat events <span style='color: rgb(" .. teamColor.r .. ", " .. teamColor.g .. ", " .. teamColor.b .. ")'>change each round</span>, and are shared between everyone who is a " .. ROLE_STRINGS[ROLE_RANDOMAN] .. ".<br><br>Some randomat events <span style='color: rgb(" .. teamColor.r .. ", " .. teamColor.g .. ", " .. teamColor.b .. ")'>cannot be bought</span>, such as ones that are supposed to start secretly."
 
-            if GetConVar("ttt_randoman_prevent_auto_randomat"):GetBool() and ConVarExists("ttt_randomat_auto") and GetConVar("ttt_randomat_auto"):GetBool() then
+            if preventAutoRandomatCvar:GetBool() and ConVarExists("ttt_randomat_auto") and GetConVar("ttt_randomat_auto"):GetBool() then
                 html = html .. "<br><br>If a " .. ROLE_STRINGS[ROLE_RANDOMAN] .. " spawns at the start of the round, <span style='color: rgb(" .. teamColor.r .. ", " .. teamColor.g .. ", " .. teamColor.b .. ")'>no randomat automatically triggers</span>."
             end
 

--- a/lua/customroles/randoman.lua
+++ b/lua/customroles/randoman.lua
@@ -23,7 +23,7 @@ CreateConVar("ttt_randoman_guaranteed_categories", "biased_innocent,fun,moderate
 
 CreateConVar("ttt_randoman_guaranteed_randomats", "", {FCVAR_NOTIFY}, "Events that will always appear in the randoma's shop, separate ids with commas.")
 
-local eventOnUnboughtDeathCvar = CreateConVar("ttt_randoman_event_on_unbought_death", 1, {FCVAR_NOTIFY}, "Whether a randomat should trigger if a randoman dies and never bought anything that round", 0, 1)
+local eventOnUnboughtDeathCvar = CreateConVar("ttt_randoman_event_on_unbought_death", 0, {FCVAR_NOTIFY}, "Whether a randomat should trigger if a randoman dies and never bought anything that round", 0, 1)
 
 ROLE.convars = {
     {

--- a/lua/customroles/randoman.lua
+++ b/lua/customroles/randoman.lua
@@ -25,6 +25,10 @@ CreateConVar("ttt_randoman_guaranteed_randomats", "", {FCVAR_NOTIFY}, "Events th
 
 local eventOnUnboughtDeathCvar = CreateConVar("ttt_randoman_event_on_unbought_death", 0, {FCVAR_NOTIFY}, "Whether a randomat should trigger if a randoman dies and never bought anything that round", 0, 1)
 
+local chooseEventOnDropCvar = CreateConVar("ttt_randoman_choose_event_on_drop", 1, {FCVAR_NOTIFY}, "Whether the held randomat item should always trigger \"Choose an event!\" after being bought by a randoman and dropped on the ground")
+
+CreateConVar("ttt_randoman_guarantee_pockets_event", 1, {FCVAR_NOTIFY}, "Whether the \"What did I find in my pocket?\" event should always be available in the randoman's shop while the beggar role is enabled")
+
 ROLE.convars = {
     {
         cvar = "ttt_randoman_banned_randomats",
@@ -88,11 +92,15 @@ if SERVER then
                 if IsValid(SWEP) then
                     SWEP.AllowDrop = true
 
-                    -- If the randoman drops this item, it is guaranteed to trigger "Choose an event!" on being picked up and used, which gives the player a choice of 5 randomats to trigger. This is so the randoman is able to give other players an interesting item, most notably for players that are the beggar role
-                    function SWEP:OnDrop()
-                        self.EventId = "choose"
+                    -- If the convar is enabled and the randoman drops this item, it is guaranteed to trigger "Choose an event!" on being picked up and used,
+                    -- which gives the player a choice of 5 randomats to trigger.
+                    -- This is so the randoman is able to give other players an interesting item, most notably for players that are the beggar role
+                    if chooseEventOnDropCvar:GetBool() then
+                        function SWEP:OnDrop()
+                            self.EventId = "choose"
 
-                        self.EventArgs = {false, false, nil, 5}
+                            self.EventArgs = {false, false, nil, 5}
+                        end
                     end
                 end
             end

--- a/lua/customroles/randoman.lua
+++ b/lua/customroles/randoman.lua
@@ -7,7 +7,9 @@ ROLE.nameshort = "ran"
 ROLE.desc = [[You are {role}!
 You're {adetective}, but you can buy randomats instead of {detective} items!]]
 ROLE.team = ROLE_TEAM_DETECTIVE
+
 ROLE.shop = {"weapon_ttt_randomat"}
+
 ROLE.loadout = {}
 ROLE.startingcredits = 1
 ROLE.selectionpredicate = function() return Randomat and type(Randomat.IsInnocentTeam) == "function" end
@@ -50,6 +52,7 @@ RegisterRole(ROLE)
 
 if SERVER then
     local categories, _ = file.Find("gamemodes/terrortown/content/materials/vgui/ttt/roles/ran/items/*.png", "THIRDPARTY")
+
     for _, cat in ipairs(categories) do
         resource.AddSingleFile("materials/vgui/ttt/roles/ran/items/" .. cat)
     end
@@ -70,24 +73,23 @@ if SERVER then
         if not blockedEvents[event.Id] then return end
 
         for _, ply in ipairs(player.GetAll()) do
-            if ply:IsRandoman() then
-                return false, "There is " .. ROLE_STRINGS_EXT[ROLE_RANDOMAN] .. " in the round and this event " .. blockedEvents[event.Id]
-            end
+            if ply:IsRandoman() then return false, "There is " .. ROLE_STRINGS_EXT[ROLE_RANDOMAN] .. " in the round and this event " .. blockedEvents[event.Id] end
         end
     end)
 
     local boughtAsRandoman = {}
-    
+
     hook.Add("TTTOrderedEquipment", "RandomanBoughtItem", function(ply, id, is_item, from_randomat)
         if ply:IsRandoman() then
             -- Let the randoman be able to drop the randomat SWEP
             if id == "weapon_ttt_randomat" then
                 local SWEP = ply:GetWeapon("weapon_ttt_randomat")
+
                 if IsValid(SWEP) then
                     SWEP.AllowDrop = true
                 end
             end
-            
+
             -- Detecting if the randoman has bought anything
             if not from_randomat then
                 boughtAsRandoman[ply] = true
@@ -100,7 +102,7 @@ if SERVER then
     end)
 
     -- Triggering a random event if the randoman dies and hasn't bought anything, and the convar is enabled
-    hook.Add("PostPlayerDeath", "RandomanDeathEventTrigger", function (ply)
+    hook.Add("PostPlayerDeath", "RandomanDeathEventTrigger", function(ply)
         if eventOnUnboughtDeathCvar:GetBool() and not boughtAsRandoman[ply] then
             Randomat:TriggerRandomEvent(ply)
             -- Just in case the randoman somehow respawns, only trigger a randomat on death once
@@ -122,12 +124,15 @@ if CLIENT then
 
             html = html .. "<span style='display: block; margin-top: 10px;'>Other players will know you are " .. ROLE_STRINGS_EXT[ROLE_DETECTIVE] .. " just by <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>looking at you</span>"
             local special_detective_mode = GetGlobalInt("ttt_detective_hide_special_mode", SPECIAL_DETECTIVE_HIDE_NONE)
+
             if special_detective_mode > SPECIAL_DETECTIVE_HIDE_NONE then
                 html = html .. ", but not what specific type of " .. ROLE_STRINGS[ROLE_DETECTIVE]
+
                 if special_detective_mode == SPECIAL_DETECTIVE_HIDE_FOR_ALL then
                     html = html .. ". <span style='color: rgb(" .. roleColor.r .. ", " .. roleColor.g .. ", " .. roleColor.b .. ")'>Not even you know what type of " .. ROLE_STRINGS[ROLE_DETECTIVE] .. " you are</span>"
                 end
             end
+
             html = html .. ".</span>"
 
             return html


### PR DESCRIPTION
See my post about this: https://discord.com/channels/844518794231414835/1126729130319290428


- Added ttt_randoman_event_on_unbought_death convar, which triggers a randomat if a randoman dies without buying anything

- Replaced the guaranteed "What did I find in my pocket?" event when the beggar is enabled, with simply adding the randomat SWEP to the randoman buy menu (Whether the beggar is enabled or not)

- Added ttt_randoman_give_used_randomats convar, which gives the randoman a "used randomat" on buying an event for converting the beggar, if the beggar is enabled